### PR TITLE
Widen admin layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         }
 
         header .bar {
-            max-width: 1200px;
+            max-width: 1400px;
             margin: auto;
             padding: 10px 16px;
             display: flex;
@@ -62,7 +62,7 @@
         }
 
         .wrap {
-            max-width: 1200px;
+            max-width: 1400px;
             margin: 20px auto;
             padding: 0 16px 48px
         }
@@ -89,13 +89,17 @@
 
         .grid {
             display: grid;
-            grid-template-columns: 1.1fr 1fr;
-            gap: 16px
+            grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+            gap: 20px
         }
 
         .panel[data-tab="items"] .grid {
-            grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+            grid-template-columns: minmax(0, 1.8fr) minmax(0, 1.1fr);
             align-items: start;
+        }
+
+        .panel[data-tab="entities"] .grid {
+            grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr);
         }
 
         @media (max-width:1000px) {


### PR DESCRIPTION
## Summary
- expand the header and content container width to better use wide screens
- enlarge grid column ratios so primary forms for items/entities have more room

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfc3fcc0d8832d9f62ca40260a86a6